### PR TITLE
fix typings for reduce/reduceRight

### DIFF
--- a/packages/reduce/module.d.ts
+++ b/packages/reduce/module.d.ts
@@ -1,9 +1,9 @@
-export type Reducer<T, I> = (
-	previous: I,
-	current: T,
+export type Reducer<T, R> = (
+	previous: R,
+	item: T,
 	index: number,
 	arr: T[]
-) => I;
+) => R;
 
 export default function <ArrayItemType, ReturnType = ArrayItemType[]>(
 	arr: ArrayItemType[],

--- a/packages/reduce/module.d.ts
+++ b/packages/reduce/module.d.ts
@@ -1,4 +1,4 @@
-export type Reducer<T, R> = (
+export type Reducer<T, R=T> = (
 	previous: R,
 	item: T,
 	index: number,

--- a/packages/reduce/module.d.ts
+++ b/packages/reduce/module.d.ts
@@ -1,6 +1,6 @@
 export type Reducer<T, R=T> = (
 	previous: R,
-	item: T,
+	current: T,
 	index: number,
 	arr: T[]
 ) => R;

--- a/packages/reduce/module.d.ts
+++ b/packages/reduce/module.d.ts
@@ -1,2 +1,12 @@
-export type Reducer<T> = (previous: T, current: T, index: number, arr: T[]) => T;
-export default function<T>(arr: T[], callback: Reducer<T>, initialValue?: T): T;
+export type Reducer<T, I> = (
+	previous: I,
+	current: T,
+	index: number,
+	arr: T[]
+) => I;
+
+export default function <ArrayItemType, ReturnType = ArrayItemType[]>(
+	arr: ArrayItemType[],
+	callback: Reducer<ArrayItemType, ReturnType>,
+	initialValue?: ReturnType
+): ReturnType;

--- a/packages/reduceRight/module.d.ts
+++ b/packages/reduceRight/module.d.ts
@@ -1,9 +1,9 @@
-export type Reducer<T, I> = (
-	previous: I,
-	current: T,
+export type Reducer<T, R> = (
+	previous: R,
+	item: T,
 	index: number,
 	arr: T[]
-) => I;
+) => R;
 
 export default function <ArrayItemType, ReturnType = ArrayItemType[]>(
 	arr: ArrayItemType[],

--- a/packages/reduceRight/module.d.ts
+++ b/packages/reduceRight/module.d.ts
@@ -1,2 +1,12 @@
-export type Reducer<T> = (previous: T, current: T, index: number, arr: T[]) => T;
-export default function<T>(arr: T[], callback: Reducer<T>, initialValue?: T): T;
+export type Reducer<T, I> = (
+	previous: I,
+	current: T,
+	index: number,
+	arr: T[]
+) => I;
+
+export default function <ArrayItemType, ReturnType = ArrayItemType[]>(
+	arr: ArrayItemType[],
+	callback: Reducer<ArrayItemType, ReturnType>,
+	initialValue?: ReturnType
+): ReturnType;


### PR DESCRIPTION
1. name the generics a little more obviously
2. return type does not have to match input type for reduce