### PR TITLE
Fix typo in readme

### DIFF
--- a/packages/some/readme.md
+++ b/packages/some/readme.md
@@ -38,7 +38,7 @@ Function to test for each element, taking three arguments:
 
 * **value** (required) -- The current element being processed in the array.
 * **index** (optional) -- The index of the current element being processed in the array.
-* **array** (optional) -- The array `map` was called upon.
+* **array** (optional) -- The array `some` was called upon.
 
 
 ## License


### PR DESCRIPTION
The README in `some` references the `map` package in the API section.